### PR TITLE
Loosen doctrine/inflector constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": "~7.0",
     "joomla/database": "~2.0@dev",
     "joomla/string": "~2.0@dev",
-    "doctrine/inflector": "1.2.0",
+    "doctrine/inflector": "~1.2",
     "joomla/event": "~2.0@dev",
     "nesbot/carbon": "~1.29"
   },


### PR DESCRIPTION
There isn't actually a direct use of the inflector in this repo, and even so it shouldn't be hard locked to only version 1.2.0.